### PR TITLE
Support for Class#cast(Object) and Class#isInstance(Object)

### DIFF
--- a/org.jenerate/src/java/org/jenerate/internal/domain/data/EqualsHashCodeGenerationData.java
+++ b/org.jenerate/src/java/org/jenerate/internal/domain/data/EqualsHashCodeGenerationData.java
@@ -22,6 +22,12 @@ public interface EqualsHashCodeGenerationData extends MethodGenerationData {
     boolean useClassComparison();
 
     /**
+     * @return {@code true} if {@link Class#cast(Object)} and {@link Class#isInstance(Object)} should be used for the equals method generation,
+     *         {@code false} otherwise.
+     */
+    boolean useClassCast();
+
+    /**
      * @return the odd numbers to be used for the hashCode generation
      */
     IInitMultNumbers getInitMultNumbers();

--- a/org.jenerate/src/java/org/jenerate/internal/domain/data/impl/EqualsHashCodeGenerationDataImpl.java
+++ b/org.jenerate/src/java/org/jenerate/internal/domain/data/impl/EqualsHashCodeGenerationDataImpl.java
@@ -14,12 +14,14 @@ public class EqualsHashCodeGenerationDataImpl extends AbstractMethodGenerationDa
     private final boolean compareReferences;
     private final IInitMultNumbers initMultNumbers;
     private final boolean classComparison;
+    private final boolean classCast;
 
     private EqualsHashCodeGenerationDataImpl(Builder builder) {
         super(builder);
         this.compareReferences = builder.builderCompareReferences;
         this.classComparison = builder.builderClassComparison;
         this.initMultNumbers = builder.builderInitMultNumbers;
+        this.classCast = builder.builderClassCast;
     }
 
     @Override
@@ -37,11 +39,17 @@ public class EqualsHashCodeGenerationDataImpl extends AbstractMethodGenerationDa
         return classComparison;
     }
 
+    @Override
+    public boolean useClassCast() {
+        return classCast;
+    }
+
     public static class Builder extends AbstractMethodGenerationData.Builder<Builder> {
 
         private boolean builderCompareReferences;
         private IInitMultNumbers builderInitMultNumbers;
         private boolean builderClassComparison;
+        private boolean builderClassCast;
 
         @Override
         public Builder getThis() {
@@ -60,6 +68,11 @@ public class EqualsHashCodeGenerationDataImpl extends AbstractMethodGenerationDa
 
         public Builder withClassComparison(boolean classComparison) {
             this.builderClassComparison = classComparison;
+            return getThis();
+        }
+
+        public Builder withClassCast(boolean classCast) {
+            this.builderClassCast = classCast;
             return getThis();
         }
 

--- a/org.jenerate/src/java/org/jenerate/internal/strategy/method/content/impl/MethodContentGenerations.java
+++ b/org.jenerate/src/java/org/jenerate/internal/strategy/method/content/impl/MethodContentGenerations.java
@@ -61,6 +61,14 @@ public final class MethodContentGenerations {
             content.append(useBlockInIfStatements ? "{\n" : "");
             content.append(" return false;");
             content.append(useBlockInIfStatements ? "\n}\n" : "");
+        } else if (data.useClassCast()) {
+            content.append("if ( !");
+            content.append(objectClass.getElementName());
+            content.append(".class.isInstance(other)");
+            content.append(")");
+            content.append(useBlockInIfStatements ? "{\n" : "");
+            content.append(" return false;");
+            content.append(useBlockInIfStatements ? "\n}\n" : "");
         } else {
             content.append("if ( !(other instanceof ");
             content.append(objectClass.getElementName());
@@ -92,10 +100,17 @@ public final class MethodContentGenerations {
             content.append(" return false;");
             content.append(useBlockInIfStatements ? "\n}\n" : "");
         }
-        content.append(elementName);
-        content.append(" castOther = (");
-        content.append(elementName);
-        content.append(") other;\n");
+        if (data.useClassCast()) {
+            content.append(elementName);
+            content.append(" castOther = ");
+            content.append(elementName);
+            content.append(".class.cast(other);\n");
+        } else {
+            content.append(elementName);
+            content.append(" castOther = (");
+            content.append(elementName);
+            content.append(") other;\n");
+        }
         content.append("return ");
         String prefix = "";
         IField[] checkedFields = data.getCheckedFields();

--- a/org.jenerate/src/java/org/jenerate/internal/ui/dialogs/strategy/EqualsHashCodeDialogStrategyHelper.java
+++ b/org.jenerate/src/java/org/jenerate/internal/ui/dialogs/strategy/EqualsHashCodeDialogStrategyHelper.java
@@ -27,12 +27,14 @@ public final class EqualsHashCodeDialogStrategyHelper {
     public static final String EQUALS_SETTINGS_SECTION = "EqualsDialog";
     private static final String SETTINGS_COMPARE_REFERENCES = "CompareReferences";
     private static final String SETTINGS_CLASS_COMPARISON = "ClassComparison";
+    private static final String SETTINGS_CLASS_CAST = "ClassCast";
 
     private IDialogSettings equalsDialogSettings;
 
     private boolean compareReferences;
     private boolean classComparison;
     private Group equalsGroup;
+    private boolean classCast;
 
     public void configureSpecificDialogSettings(IDialogSettings dialogSettings) {
         IDialogSettings equalsSettings = dialogSettings.getSection(EQUALS_SETTINGS_SECTION);
@@ -43,11 +45,13 @@ public final class EqualsHashCodeDialogStrategyHelper {
 
         compareReferences = equalsSettings.getBoolean(SETTINGS_COMPARE_REFERENCES);
         classComparison = equalsSettings.getBoolean(SETTINGS_CLASS_COMPARISON);
+        classCast = equalsSettings.getBoolean(SETTINGS_CLASS_CAST);
     }
 
     public void callbackBeforeDialogClosing() {
         equalsDialogSettings.put(SETTINGS_COMPARE_REFERENCES, compareReferences);
         equalsDialogSettings.put(SETTINGS_CLASS_COMPARISON, classComparison);
+        equalsDialogSettings.put(SETTINGS_CLASS_CAST, classCast);
     }
 
     public void createSpecificComponents(FieldDialog<EqualsHashCodeGenerationData> fieldDialog) {
@@ -74,7 +78,8 @@ public final class EqualsHashCodeDialogStrategyHelper {
                 .withUseBlockInIfStatements(methodGenerationData.useBlockInIfStatements())
                 .withUseGettersInsteadOfFields(methodGenerationData.useGettersInsteadOfFields())
                 .withCompareReferences(compareReferences)
-                .withClassComparison(classComparison);
+                .withClassComparison(classComparison)
+                .withClassCast(classCast);
         //@formatter:on
     }
 
@@ -88,6 +93,7 @@ public final class EqualsHashCodeDialogStrategyHelper {
 
         createAndAddCompareReferencesButton(equalsGroup);
         createAndAddClassComparisonButton(equalsGroup);
+        createAndAddClassCastButton(equalsGroup);
 
         return editableComposite;
     }
@@ -130,5 +136,25 @@ public final class EqualsHashCodeDialogStrategyHelper {
             }
         });
         comparisonButton.setSelection(classComparison);
+    }
+
+    private void createAndAddClassCastButton(Group group) {
+        Button comparisonButton = new Button(group, SWT.CHECK);
+        comparisonButton.setText("Use Class#cast(Object) and Class#isInstance(Object) instead of native cast and instanceOf");
+        comparisonButton.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL));
+
+        comparisonButton.addSelectionListener(new SelectionListener() {
+
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                classCast = (((Button) e.widget).getSelection());
+            }
+
+            @Override
+            public void widgetDefaultSelected(SelectionEvent e) {
+                widgetSelected(e);
+            }
+        });
+        comparisonButton.setSelection(classCast);
     }
 }

--- a/org.jenerate/src/test/org/jenerate/internal/strategy/method/content/impl/java/JavaEqualsMethodContentTest.java
+++ b/org.jenerate/src/test/org/jenerate/internal/strategy/method/content/impl/java/JavaEqualsMethodContentTest.java
@@ -139,4 +139,24 @@ public class JavaEqualsMethodContentTest
                 content);
     }
 
+    @Test
+    public void testGetMethodContentWithClassCast() throws Exception {
+        when(data.useClassCast()).thenReturn(true);
+        String content = methodContent.getMethodContent(objectClass, data);
+        assertEquals("if ( !Test.class.isInstance(other)) return false;"
+                + "Test castOther = Test.class.cast(other);\nreturn Objects.equals(field1, castOther.field1) && "
+                + "Objects.equals(field2, castOther.field2);\n", content);
+    }
+
+    @Test
+    public void testGetMethodContentWithClassCastAndUseBlocksInIfStatements() throws Exception {
+        when(data.useClassCast()).thenReturn(true);
+        when(data.useBlockInIfStatements()).thenReturn(true);
+        String content = methodContent.getMethodContent(objectClass, data);
+        assertEquals(
+                "if ( !Test.class.isInstance(other))"
+                        + "{\n return false;\n}\nTest castOther = Test.class.cast(other);\nreturn "
+                        + "Objects.equals(field1, castOther.field1) && Objects.equals(field2, castOther.field2);\n",
+                content);
+    }
 }


### PR DESCRIPTION
Hello @maximeAudrain,
here is a new Option for your Jenerate Plugin to use the Method Class#cast(Object) and Class#isInstance(Object).
I am not familiar with the Eclipse Development, but it works as expected. The only Option what is missing is to disable and uncheck the box "Use class comparison instead of instanceOf.

Let me know what you think about the new feature.

Best regards
Martin